### PR TITLE
Modificação em quest 2

### DIFF
--- a/classes/renegado/quest-c-2.pm
+++ b/classes/renegado/quest-c-2.pm
@@ -1,5 +1,6 @@
 sub initParamsQuestClasse2 {
-	if (&eval($char->{jobID}) =~ /$paramsClasses{idC1}/) {
+	$idAtual = pegarID()
+	if (/$paramsClasses{idC1}/ =~ /$idAtual/) {
 		iconf 510 7 1 0 #ervaAzul
 		iconf 957 10 1 0 #unhaApodrecida
 		iconf 932 10 1 0 #osso

--- a/classes/renegado/quest-c-2.pm
+++ b/classes/renegado/quest-c-2.pm
@@ -1,9 +1,11 @@
 sub initParamsQuestClasse2 {
-	Commands::run("iconf 510 7 1 0" ); #ervaAzul
-	Commands::run("iconf 957 10 1 0"); #unhaApodrecida
-	Commands::run("iconf 932 10 1 0"); #osso
-	Commands::run("iconf 958 10 1 0"); #mandibula
-	Commands::run("conf -f questc2_implementada true");
+	if (&eval($char->{jobID}) =~ /$paramsClasses{idC1}/) {
+		iconf 510 7 1 0 #ervaAzul
+		iconf 957 10 1 0 #unhaApodrecida
+		iconf 932 10 1 0 #osso
+		iconf 958 10 1 0 #mandibula
+		conf -f questc2_implementada true
+	}
 }
 
 #From- Macro Quest Arruaceiro 2.0

--- a/comum/init.pm
+++ b/comum/init.pm
@@ -55,7 +55,7 @@ automacro init {
 		initParamsQuestClasse1T()
 		
 		# Esse sub configura os itens da quest de classe 2 (para não vender nem guardar)
-		initParamsQuestClasse2()
+		call initParamsQuestClasse2
 		
 		# Esse sub gera a hash %paramsQuestClasse2T com a seguinte key:
 		# $paramsQuestClasse2T{npc}


### PR DESCRIPTION
O bot só precisa pegar esses itens enquanto for classe 1


-  não tem como pegar enquanto é noviço
-  não precisa pegar depois que virar classe 2
- e muito menos quando é transclasse...

o sub precisa virar macro para que a variável `$paramClasses{idC1}` possa ser usada
o que acha? se for aprovado já mudo todos os outros