### PR TITLE
Alguns ajustes

### DIFF
--- a/classes/bioquimico/quest-eden.pm
+++ b/classes/bioquimico/quest-eden.pm
@@ -2,9 +2,9 @@ sub initParamsQuestEden {
     my %paramsQuestEden = (
         armaLevel26e40 => 'sabre|espada',
         armaLevel60 => 'sabre|espada',
-        IDarmaIniciante => 16004,
-        IDarmaIntermediario => 16005,
-        IDarmaEden => 1391
+        IDarmaIniciante => 13423, # Sabre Valhalla Iniciante
+        IDarmaIntermediario => 13424, # Sabre Valhalla Intermediário
+        IDarmaEden => 1391 # Machado de 2 Mãos I do Éden
     );
     my $eventMacro = $eventMacro::Data::eventMacro;
     $eventMacro->set_full_hash('paramsQuestEden', \%paramsQuestEden);

--- a/comum/setSaveIn.pm
+++ b/comum/setSaveIn.pm
@@ -2,7 +2,7 @@ macro SetSaveIn {
     call pararDeAtacar
     do conf lockMap none
     do conf -f saveMap_storage_sequence c r1
-	do conf -f saveMap_save_sequence c r0
+    do conf -f saveMap_save_sequence c r0
     switch ($.param[0]) {
         case (=~ /einbroch/i ) {
             do conf -f saveMap_wanted einbroch

--- a/comum/setSaveIn.pm
+++ b/comum/setSaveIn.pm
@@ -2,6 +2,7 @@ macro SetSaveIn {
     call pararDeAtacar
     do conf lockMap none
     do conf -f saveMap_storage_sequence c r1
+	do conf -f saveMap_save_sequence c r0
     switch ($.param[0]) {
         case (=~ /einbroch/i ) {
             do conf -f saveMap_wanted einbroch
@@ -163,10 +164,10 @@ automacro FalarComKafra {
     timeout 20
     call {
         log ==============================================================
-        log Falando com kafra na posição &config(saveMap_kafra_position) 
-        log Usando a sequência '&config(saveMap_save_sequence)'
+        log Falando com kafra na posição: &config(saveMap_kafra_position)
+        log Usando a sequência: &config(saveMap_save_sequence)
         log ==============================================================
-        do talknpc &config(saveMap_kafra_position) c r0
+        do talknpc &config(saveMap_kafra_position) &config(saveMap_save_sequence)
     }
 }
 


### PR DESCRIPTION
quest-eden.pm evitar Erro: ou a ID do item está incorreta, ou você não possui esse equipamento.
setSaveIn um dos log não imprimia a sequência de salvamento (c r0)