### PR TITLE
Erro ao desequipar Camisa de Algodão/Faca [3]

### DIFF
--- a/comum/quest-renascer.pm
+++ b/comum/quest-renascer.pm
@@ -31,8 +31,8 @@ automacro questRenascer_chegueilvl99 {
             [
             do conf dealAuto 3
             do conf dealAuto_names $parametrosQuestClasseRenascer{amigo}
-            do iconf Camisa de Algodão 0 1 0
-            do iconf "Faca [3]" 0 1 0
+            do iconf 2301 0 1 0 # Camisa de Algodão
+            do iconf 1201 0 1 0 # Faca [3]
 
             # é uma forma que eu pensei de desabilitar TODOS os getAuto
             # independente de quantos hajam


### PR DESCRIPTION
Ao usar o iconf com o nome do item "Camisa de Algodão", o plugin acaba alterando a configuração da Camisa de Algodão [1] e nunca consegue guardar a camisa de algodão sem slot no armazém. Já no caso da Faca [3], o plugin não consegue encontrar a referência no arquivo de itens.
Alterei pelo ID dos itens e o personagem armazenou os dois itens corretamente.