### PR TITLE
Bug que previne de salvar na cidade em alguns casos

### DIFF
--- a/comum/salvar-na-cidade.pm
+++ b/comum/salvar-na-cidade.pm
@@ -114,7 +114,6 @@ automacro definirVariavelSaveMap {
     ConfigKeyNot saveMap_desejado           none
     ConfigKeyNot saveMap_posicaoKafra       none
     ConfigKeyNot saveMap_posicaoNpcVenda    none
-    ConfigKeyNot saveMap_posicaoNpcPraPocao none
     ConfigKey naSequenciaDeSalvamento true
     priority -4
     CheckOnAI auto, manual

--- a/comum/salvar-na-cidade.pm
+++ b/comum/salvar-na-cidade.pm
@@ -129,7 +129,6 @@ automacro salvarNaCidade_bugged {
     ConfigKey saveMap_desejado           none
     ConfigKey saveMap_posicaoKafra       none
     ConfigKey saveMap_posicaoNpcVenda    none
-    ConfigKey saveMap_posicaoNpcPraPocao none
     ConfigKey naSequenciaDeSalvamento true
     CheckOnAI auto, manual
     call {


### PR DESCRIPTION
A checagem do ```ConfigKey saveMap_posicaoNpcPraPocao none``` nao faz sentido em alguns casos (como Hugel), devido a:
```
case ( =~ /hugel/i ) {
            do conf -f saveMap_desejado hugel
            do conf -f saveMap_posicaoKafra 88 168
            do conf -f saveMap_posicaoNpcVenda hugel 77 167
            do conf -f saveMap_posicaoNpcPraPocao # não tem infelizmente!
```
nao setamos nada no saveMap_posicaoNpcPraPocao, entao o check estava fazendo com que o evento nao fosse chamado nesse caso.