### PR TITLE
Fixing quest eden loop

### DIFF
--- a/comum/quest-eden.pm
+++ b/comum/quest-eden.pm
@@ -168,6 +168,7 @@ automacro questEden12_iniciando {
     BaseLevel 12..17
     exclusive 1
     QuestInactive 7128
+    ConfigKeyNot membroDoEden sim
     ConfigKeyNot fazerQuestEden nao
     ConfigKeyNot naSequenciaDeSalvamento true
     ConfigKeyNot quest_eden em_curso


### PR DESCRIPTION
Pequeno bugzinho que pode fazer seu char ficar em loop tentando fazer a quest do eden no lvl 12-17 enquanto ele ja eh membro do eden.